### PR TITLE
feat-KIS 종목 시세 데이터 websocket 실시간으로 받기

### DIFF
--- a/Coconut-Backend/build.gradle
+++ b/Coconut-Backend/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	implementation 'org.java-websocket:Java-WebSocket:1.5.2'
 	implementation 'org.json:json:20210307'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/Coconut-Backend/src/main/java/com/coconut/stock_app/config/ApiConfig.java
+++ b/Coconut-Backend/src/main/java/com/coconut/stock_app/config/ApiConfig.java
@@ -13,5 +13,5 @@ public class ApiConfig {
     private String appKey;
     private String appSecret;
     private String restapiUrl;
-    private String websocketUrl;
+    private String stockPriceEndpoint;
 }

--- a/Coconut-Backend/src/main/java/com/coconut/stock_app/config/SecurityConfig.java
+++ b/Coconut-Backend/src/main/java/com/coconut/stock_app/config/SecurityConfig.java
@@ -13,10 +13,11 @@ public class SecurityConfig {
         http
                 .authorizeRequests(authorizeRequests ->
                         authorizeRequests
+                                .requestMatchers("/**").permitAll()
                                 .requestMatchers("/api/v1/stock/**").permitAll() // /api/v1/stock 하위 모든 경로 허용
                                 .anyRequest().authenticated()
-                )
-                .csrf().disable(); // CSRF 비활성화 (필요한 경우)
+                );
+                //.csrf().disable(); // CSRF 비활성화 (필요한 경우)
 
         return http.build();
     }

--- a/Coconut-Backend/src/main/java/com/coconut/stock_app/controller/StockController.java
+++ b/Coconut-Backend/src/main/java/com/coconut/stock_app/controller/StockController.java
@@ -1,17 +1,21 @@
 package com.coconut.stock_app.controller;
 
+import com.coconut.stock_app.service.KISWebSocketClient;
 import com.coconut.stock_app.service.StockService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.net.URISyntaxException;
 import java.util.Map;
 
 @RestController
 @RequestMapping("/api/v1/stock")
 @RequiredArgsConstructor
 public class StockController {
+    private final KISWebSocketClient kisWebSocketClient;
     private final StockService stockService;
 
     @GetMapping("/kospi")
@@ -23,4 +27,16 @@ public class StockController {
     public Map getKOSDAQIndex() {
         return stockService.getKOSDAQIndex();
     }
+
+    @GetMapping("/subscribe")
+    public String subscribeStock() {
+        try {
+            kisWebSocketClient.connect();
+            return "WebSocket 연결 및 종목 구독 성공!";
+        } catch (URISyntaxException e) {
+            e.printStackTrace();
+            return "WebSocket 연결 실패: " + e.getMessage();
+        }
+    }
+
 }

--- a/Coconut-Backend/src/main/java/com/coconut/stock_app/service/KISApiService.java
+++ b/Coconut-Backend/src/main/java/com/coconut/stock_app/service/KISApiService.java
@@ -62,7 +62,7 @@ public class KISApiService {
         }
     }
 
-    public String getWebSocketKey(String apiUrl) { // URL을 메서드 매개변수로 받음
+    public String getWebSocketKey() { // URL을 메서드 매개변수로 받음
         // 요청 헤더 설정
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
@@ -78,7 +78,7 @@ public class KISApiService {
 
         // RestTemplate 사용하여 POST 요청 보내기
         RestTemplate restTemplate = new RestTemplate();
-        ResponseEntity<String> response = restTemplate.exchange(apiUrl + "/oauth2/Approval", HttpMethod.POST, entity,
+        ResponseEntity<String> response = restTemplate.exchange(apiConfig.getRestapiUrl() + "/oauth2/Approval", HttpMethod.POST, entity,
                 String.class);
 
         // 응답 JSON에서 approval_key 추출

--- a/Coconut-Backend/src/main/java/com/coconut/stock_app/service/KISWebSocketClient.java
+++ b/Coconut-Backend/src/main/java/com/coconut/stock_app/service/KISWebSocketClient.java
@@ -1,0 +1,103 @@
+package com.coconut.stock_app.service;
+
+import com.coconut.stock_app.config.ApiConfig;
+import lombok.RequiredArgsConstructor;
+import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.handshake.ServerHandshake;
+import org.json.JSONObject;
+import org.springframework.stereotype.Service;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+@Service
+@RequiredArgsConstructor
+public class KISWebSocketClient {
+    private WebSocketClient webSocketClient;
+    private final ApiConfig apiConfig;
+    private final KISApiService kisApiService;
+
+    public void connect() throws URISyntaxException {
+        // WebSocket 접속키 가져오기
+        String approvalKey = kisApiService.getWebSocketKey();
+        String uri = apiConfig.getStockPriceEndpoint() + "?approval_key=" + approvalKey;
+
+        webSocketClient = new WebSocketClient(new URI(uri)) {
+            @Override
+            public void onOpen(ServerHandshake handshake) {
+                System.out.println("WebSocket 연결 성공!");
+                // PINGPONG 메시지 확인 후 구독 요청
+                new Thread(() -> {
+                    try {
+                        Thread.sleep(2000); // 잠시 대기 후 구독 요청 전송
+                        subscribeStock("005930", approvalKey);
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                }).start();
+            }
+
+            @Override
+            public void onMessage(String message) {
+                System.out.println("Received Message: " + message);
+
+                // 1. JSON 형식인지 확인
+                if (message.startsWith("{")) {
+                    try {
+                        // JSON 형식으로 파싱
+                        JSONObject jsonObject = new JSONObject(message);
+
+                        // PINGPONG 메시지 무시
+                        if (jsonObject.has("header") && "PINGPONG".equals(jsonObject.getJSONObject("header").optString("tr_id"))) {
+                            return;
+                        }
+                    } catch (Exception e) {
+                        System.err.println("JSON 파싱 오류 발생: " + e.getMessage());
+                    }
+                }
+
+
+            }
+
+            @Override
+            public void onClose(int code, String reason, boolean remote) {
+                System.out.println("WebSocket 연결 종료: " + reason);
+            }
+
+            @Override
+            public void onError(Exception ex) {
+                System.err.println("WebSocket 오류 발생: " + ex.getMessage());
+            }
+        };
+
+        webSocketClient.connect();
+    }
+
+    // 종목 구독 요청 메서드 수정
+    private void subscribeStock(String stockCode, String approvalKey) {
+        // 요청 JSON 생성
+        JSONObject request = new JSONObject();
+
+        // Header 구성
+        JSONObject header = new JSONObject();
+        header.put("approval_key", approvalKey);
+        header.put("custtype", "P");
+        header.put("tr_type", "1");
+        header.put("content-type", "utf-8");
+
+        // Body 구성
+        JSONObject body = new JSONObject();
+        JSONObject input = new JSONObject();
+        input.put("tr_id", "H0STCNT0");
+        input.put("tr_key", stockCode);
+        body.put("input", input);
+
+        // 전체 요청 JSON 조립
+        request.put("header", header);
+        request.put("body", body);
+
+        // WebSocket으로 메시지 전송
+        webSocketClient.send(request.toString());
+        System.out.println("종목 시세 구독 요청 전송: " + request.toString());
+    }
+}

--- a/Coconut-Backend/src/test/java/com/coconut/stock_app/service/WebSocketKeyServiceTest.java
+++ b/Coconut-Backend/src/test/java/com/coconut/stock_app/service/WebSocketKeyServiceTest.java
@@ -22,7 +22,7 @@ public class WebSocketKeyServiceTest {
         String apiUrl = apiConfig.getRestapiUrl();
 
         // webSocketKeyService의 메서드를 호출하여 키를 가져옵니다.
-        String webSocketKey = KISApiService.getWebSocketKey(apiUrl);
+        String webSocketKey = KISApiService.getWebSocketKey();
 
         // WebSocket 접근키 검증
         assertNotNull(webSocketKey, "WebSocket 접근키를 받아오지 못했습니다.");


### PR DESCRIPTION
### 개요
- KIS 종목 시세 데이터 websocket 실시간으로 받기
### 관련 이슈
- #19 
### 변경 사항
- KIS webSocket 연결
- 종목 데이터 불러오기

### 테스트 결과 (선택 사항)
- [x] 로컬 테스트 완료
- [x] merge된 브랜치 확인