### PR TITLE
feat(#80): MySQL 종목 데이터 API 구현

### DIFF
--- a/Coconut-Backend/src/main/java/com/coconut/stock_app/controller/StockChartController.java
+++ b/Coconut-Backend/src/main/java/com/coconut/stock_app/controller/StockChartController.java
@@ -1,0 +1,41 @@
+package com.coconut.stock_app.controller;
+
+import com.coconut.stock_app.dto.stock.StockChartResponse;
+import com.coconut.stock_app.service.StockChartService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/stocks")
+@RequiredArgsConstructor
+@Slf4j
+public class StockChartController {
+
+    private final StockChartService stockChartService;
+
+    @GetMapping("/{stockCode}/charts")
+    public ResponseEntity<List<StockChartResponse>> getStockChartData(
+            @PathVariable String stockCode,
+            @RequestParam(required = false) String fromTime) {
+        try {
+            List<StockChartResponse> response;
+            if (fromTime != null) {
+                response = stockChartService.getStockChartDataAfter(stockCode, fromTime);
+            } else {
+                response = stockChartService.getStockChartData(stockCode);
+            }
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            log.error("Failed to get stock chart data", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+}

--- a/Coconut-Backend/src/main/java/com/coconut/stock_app/dto/stock/StockChartResponse.java
+++ b/Coconut-Backend/src/main/java/com/coconut/stock_app/dto/stock/StockChartResponse.java
@@ -1,0 +1,42 @@
+package com.coconut.stock_app.dto.stock;
+
+import com.coconut.stock_app.entity.cloud.StockChart;
+import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StockChartResponse {
+    private Long chartId;
+    private String stockCode;
+    private BigDecimal openPrice;
+    private BigDecimal highPrice;
+    private BigDecimal lowPrice;
+    private BigDecimal currentPrice;
+    private String versusSign;
+    private BigDecimal contingentVol;
+    private BigDecimal accumulatedVol;
+    private BigDecimal accumulatedAmount;
+    private String time;
+
+    public static StockChartResponse fromEntity(StockChart entity) {
+        return StockChartResponse.builder()
+                .chartId(entity.getChartId())
+                .stockCode(entity.getStock().getStockCode())
+                .openPrice(entity.getOpenPrice())
+                .highPrice(entity.getHighPrice())
+                .lowPrice(entity.getLowPrice())
+                .currentPrice(entity.getCurrentPrice())
+                .versusSign(entity.getVersusSign())
+                .contingentVol(entity.getContingentVol())
+                .accumulatedVol(entity.getAccumulatedVol())
+                .accumulatedAmount(entity.getAccumulatedAmount())
+                .time(entity.getTime())
+                .build();
+    }
+}

--- a/Coconut-Backend/src/main/java/com/coconut/stock_app/repository/cloud/StockChartRepository.java
+++ b/Coconut-Backend/src/main/java/com/coconut/stock_app/repository/cloud/StockChartRepository.java
@@ -1,9 +1,16 @@
 package com.coconut.stock_app.repository.cloud;
 
 import com.coconut.stock_app.entity.cloud.StockChart;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface StockChartRepository extends JpaRepository<StockChart, Long> {
+    // 특정 종목의 전체 차트 데이터 조회
+    List<StockChart> findByStockStockCodeOrderByTimeAsc(String stockCode);
+
+    // 특정 종목의 특정 시간 이후 데이터 조회
+    List<StockChart> findByStockStockCodeAndTimeGreaterThanOrderByTimeAsc(
+            String stockCode, String time);
 }

--- a/Coconut-Backend/src/main/java/com/coconut/stock_app/service/StockChartService.java
+++ b/Coconut-Backend/src/main/java/com/coconut/stock_app/service/StockChartService.java
@@ -1,0 +1,9 @@
+package com.coconut.stock_app.service;
+
+import com.coconut.stock_app.dto.stock.StockChartResponse;
+import java.util.List;
+
+public interface StockChartService {
+    List<StockChartResponse> getStockChartData(String stockCode);
+    List<StockChartResponse> getStockChartDataAfter(String stockCode, String time);
+}

--- a/Coconut-Backend/src/main/java/com/coconut/stock_app/service/impl/StockChartServiceImpl.java
+++ b/Coconut-Backend/src/main/java/com/coconut/stock_app/service/impl/StockChartServiceImpl.java
@@ -1,0 +1,51 @@
+package com.coconut.stock_app.service.impl;
+
+import com.coconut.stock_app.dto.stock.StockChartResponse;
+import com.coconut.stock_app.entity.cloud.StockChart;
+import com.coconut.stock_app.repository.cloud.StockChartRepository;
+import com.coconut.stock_app.service.StockChartService;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class StockChartServiceImpl implements StockChartService {
+
+    private final StockChartRepository stockChartRepository;
+
+    @Override
+    public List<StockChartResponse> getStockChartData(String stockCode) {
+        try {
+            log.info("Fetching chart data for stock: {}", stockCode);
+            List<StockChart> chartData = stockChartRepository
+                    .findByStockStockCodeOrderByTimeAsc(stockCode);
+
+            return chartData.stream()
+                    .map(StockChartResponse::fromEntity)
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            log.error("Failed to get stock chart data for {}", stockCode, e);
+            throw new RuntimeException("Failed to get stock chart data", e);
+        }
+    }
+
+    @Override
+    public List<StockChartResponse> getStockChartDataAfter(String stockCode, String time) {
+        try {
+            log.info("Fetching chart data for stock: {} after time: {}", stockCode, time);
+            List<StockChart> chartData = stockChartRepository
+                    .findByStockStockCodeAndTimeGreaterThanOrderByTimeAsc(stockCode, time);
+
+            return chartData.stream()
+                    .map(StockChartResponse::fromEntity)
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            log.error("Failed to get stock chart data for {} after {}", stockCode, time, e);
+            throw new RuntimeException("Failed to get stock chart data", e);
+        }
+    }
+}


### PR DESCRIPTION
### 개요
- FE에서 MySQL 종목 데이터 API로 차트 만들기 위한 임시 API

### 관련 이슈
- #73
- #77 

### 테스트 결과 (선택 사항)
- [x] 로컬 테스트 완료
- [x] merge된 브랜치 확인